### PR TITLE
fix: return headers and data.data

### DIFF
--- a/src/Components/Endpoint/Endpoint.tsx
+++ b/src/Components/Endpoint/Endpoint.tsx
@@ -91,6 +91,7 @@ const Endpoint: React.FC = () => {
 
   useEffect(() => {
     const { data, isError, error, isLoading, isFetching } = result;
+
     if (isError) {
       const errorMessage = parseQueryError(error, language);
       enqueueSnackbar(errorMessage, {
@@ -99,7 +100,7 @@ const Endpoint: React.FC = () => {
     }
 
     const isButtonDisabled =
-      !!!data || isError || isFetching || isLoading || !urlInputValue;
+      !!!data?.data || isError || isFetching || isLoading || !urlInputValue;
     setDocsButtonDisabled(isButtonDisabled);
     dispatch(hasSchema(!isButtonDisabled));
     dispatch(setIsLoadingSchema(isLoading || isFetching));

--- a/src/api/rtk-api.tsx
+++ b/src/api/rtk-api.tsx
@@ -19,6 +19,9 @@ export const rtkqApi = createApi({
             body: {
               operationName: 'IntrospectionQuery',
               query: INTROSPECION_QUERY,
+              headers: {
+                'Content-type': 'application/json',
+              },
             },
           };
         }


### PR DESCRIPTION
1. Task: [GraphiQL](https://github.com/rolling-scopes-school/tasks/blob/master/react/modules/graphiql.md)
2. Screenshot:
3. Deploy: [graphiql-app]()
4. Done \_\_.12.2023 / Deadline 08.01.2024
5. Score:

вернула в body headers, иначе не отправлялись headers
но тогда https://countries.trevorblades.com/ не работает


добавила data?.data  в  isButtonDisabled, но все равно сейчас поведение кнопки не нравиться еще.
что data берется от предыдущего вызова и поэтому кнопка видима.
